### PR TITLE
JSON is a lang returned by PP gist

### DIFF
--- a/fourth-wall.js
+++ b/fourth-wall.js
@@ -185,7 +185,7 @@
                             var filedata = gistdata.data.files[file],
                                 lang = filedata.language;
 
-                            if (lang == 'JavaScript' || lang == null) {
+                            if (lang == 'JavaScript' || lang == 'JSON' || lang == null) {
                                 var o = JSON.parse(filedata.content);
                                 if (o) {
                                     objects.push(o);


### PR DESCRIPTION
The change in #8 broke fourth wall for Performance Platform as the
language returned was JSON and thus no longer parsed and pushed. I've
added it back as a valid language.
