### PR TITLE
Use real time rather than working time

### DIFF
--- a/fourth-wall.js
+++ b/fourth-wall.js
@@ -261,38 +261,7 @@
         elapsedSeconds: function (created_at) {
             var now = moment();
             created_at = moment(created_at);
-
-            var elapsed = 0;
-            var date = moment(created_at).startOf('day');
-            while (date < now) {
-                elapsed += this.workingTimeForDay(date, {
-                    min: created_at,
-                    max: now
-                });
-                date.add(1, 'days');
-            }
-
-            return elapsed;
-        },
-
-        startOfWorkingDay: function (date) {
-            return moment(date).startOf('day').hours(9).minutes(30);
-        },
-
-        endOfWorkingDay: function (date) {
-            return moment(date).startOf('day').hours(17).minutes(30);
-        },
-
-        workingTimeForDay: function (date, options) {
-            options = options || {};
-            date = moment(date).startOf('day');
-            var isWeekend = date.day() === 0 || date.day() === 6;
-            if (isWeekend) {
-                return 0;
-            }
-            var min = Math.max(+(options.min || 0), +this.startOfWorkingDay(date));
-            var max = Math.min(+(options.max || Infinity), +this.endOfWorkingDay(date));
-            return Math.max((max - min) / 1000, 0);
+            return now.unix() - created_at.unix();
         }
     });
 

--- a/spec/spec.fourth-wall.js
+++ b/spec/spec.fourth-wall.js
@@ -219,7 +219,7 @@ describe("Fourth Wall", function () {
     });
 
     describe("elapsedSeconds", function () {
-      it("calculates seconds in working time since creation date", function () {
+      it("calculates seconds since creation date", function () {
         setupMoment("2013-09-09T10:01:00+01:00", window)
         spyOn(FourthWall.Comment.prototype, "fetch");
         spyOn(FourthWall.Status.prototype, "fetch");
@@ -229,14 +229,10 @@ describe("Fourth Wall", function () {
           collection: {}
         });
         var result = pull.parse({ created_at: "2013-09-02T10:00:00+01:00" });
-        var fullDay = 8 * 60 * 60;
-        var expected = 
-          7.5 * 60 * 60 // day 1: from 10:00 to 17:30
-          + fullDay * 4 // days 2 - 4: tuesday to friday, weekend ignored
-          + 31 * 60 // today: from 9:30 to 10:01
+        var fullDay = 24 * 60 * 60;
+        var expected = 7 * fullDay + 60;
 
-        expect(result.elapsed_time).toBeGreaterThan(expected - 120);
-        expect(result.elapsed_time).toBeLessThan(expected + 120);
+        expect(result.elapsed_time).toBe(expected);
       });
     });
   });


### PR DESCRIPTION
Working time for pull requests is really confusing and doesn't map to a
standard view of the world. It also doesn't map to display as the display
is done in 24 hour days.
