### PR TITLE
Parse file correctly for authenticated repo request

### DIFF
--- a/spec/spec.fourth-wall.js
+++ b/spec/spec.fourth-wall.js
@@ -12,6 +12,23 @@ function setupMoment(date, anObject) {
 
 describe("Fourth Wall", function () {
 
+  describe("getQueryParameters", function () {
+    it("should convert a query string into a params object", function () {
+      var query_params = FourthWall.getQueryParameters("?ref=gh-pages&token=nonsense");
+      expect(query_params).toEqual({'ref': 'gh-pages', 'token': 'nonsense'});
+    });
+  });
+  describe("buildQueryString", function () {
+    it("should convert a query string into a params object", function () {
+      var query_string = FourthWall.buildQueryString({'ref': 'gh-pages', 'token': 'nonsense'});
+      expect(query_string).toEqual("?ref=gh-pages&token=nonsense");
+    });
+    it("should handle an empty object", function () {
+      var query_string = FourthWall.buildQueryString({});
+      expect(query_string).toEqual("");
+    });
+  });
+
   describe("getToken", function () {
     beforeEach(function () {
       spyOn(FourthWall, 'getQueryVariable');


### PR DESCRIPTION
This allows the use of files in repos with authentication. The previous
url construction for github api requests did not correctly construct
query params to authenticate and so very quickly hit the github rate
limit.
