### PR TITLE
This enables using alternative githubs on file.

### DIFF
--- a/fourth-wall.js
+++ b/fourth-wall.js
@@ -85,12 +85,13 @@
 
         var contents = JSON.parse(
             atob(data.content)
-        ).map(function (key, val) {
-            // map to gist style keys
-            return {
-                'userName': key.owner || key.userName,
-                'repo': key.name ||  key.repo
-            };
+        ).map(function (item) {
+            // map to ensure gist style keys present
+            // we extend the item to ensure any provided baseUrls are kept
+            return $.extend(item, {
+                'userName': item.owner || item.userName,
+                'repo': item.name ||  item.repo
+            });
         });
 
         that.reset.call(that, contents);


### PR DESCRIPTION
Because the current file format is supposed to allow the standard format
as well as something slightly different it is mutating the passed in
config in order to work. This currently missed off the baseUrl option
which allows us to contact different githubs. This is a bit of a hack
but I don't want to break backwards compatibility with this format.
