### PR TITLE
Prevent wrapping of the elapsed time

### DIFF
--- a/fourth-wall.css
+++ b/fourth-wall.css
@@ -88,6 +88,7 @@ body {
     line-height: 110%;
     font-size: 1.5em;
     font-weight: 700;
+    white-space: nowrap;
 }
 
 h2 {


### PR DESCRIPTION
It looks nicer and it's easier to scan if it's not wrapped.