### PR TITLE
Add the ability to specify users to show PRs from, through the gist

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -33,6 +33,16 @@ The Gist should contain one or more JSON files with this syntax:
 ]
 ```
 
+Optionally, the Gist can contain a JSON file named `users`, to list
+users the team cares about. Fourth Wall will then only display PRs
+across your tracked apps opened by these users. Syntax:
+```json
+[
+  "username0",
+  "username1"
+]
+```
+
 If the Gist contains a file with the language set to `CSS`, it will be injected
 into a `<style>` block in the document head, so you can override the default
 styling without having to fork this repo.
@@ -41,6 +51,7 @@ Examples:
 
 * A simple list of repos for the [Performance Platform team](https://gist.github.com/abersager/6449384)
 * A list of repos and custom CSS for the [Mainstream team](https://gist.github.com/norm/7248264)
+* A list of repos, custom CSS and users for the [Core team](https://gist.github.com/issyl0/70cf0c8f3d0b1ccd2f6e)
 
 ## Support for other githubs
 

--- a/fourth-wall.css
+++ b/fourth-wall.css
@@ -65,6 +65,10 @@ body {
 #pulls li.age-old {
     background: #F47738;
 }
+#pulls li.unimportant-user {
+  display: none;
+}
+
 #pulls li.thumbsup {
     background: #5c9317;
 }

--- a/fourth-wall.js
+++ b/fourth-wall.js
@@ -52,7 +52,7 @@
     };
 
     FourthWall.parseGistData = function (gistData, that) {
-        var objects = [];
+        var config = [];
         for (var file in gistData.data.files) {
             if (gistData.data.files.hasOwnProperty(file)) {
                 var filedata = gistData.data.files[file],
@@ -61,7 +61,7 @@
                 if (lang == 'JavaScript' || lang == 'JSON' || lang == null) {
                     var o = JSON.parse(filedata.content);
                     if (o) {
-                        objects.push(o);
+                        config.push(o);
                     }
                 }
                 if (lang == 'CSS') {
@@ -71,8 +71,8 @@
                 }
             }
         }
-        if (objects.length > 0) {
-            that.reset.call(that, objects[0]);
+        if (config.length > 0) {
+            that.reset.call(that, config[0]);
         }
     };
 

--- a/fourth-wall.js
+++ b/fourth-wall.js
@@ -1,5 +1,6 @@
 (function () {
     var FourthWall = {};
+    var users = [];
 
     FourthWall.getQueryParameters = function(str) {
       return str
@@ -58,19 +59,24 @@
                 var filedata = gistData.data.files[file],
                     lang = filedata.language;
 
-                if (lang == 'JavaScript' || lang == 'JSON' || lang == null) {
-                    var o = JSON.parse(filedata.content);
-                    if (o) {
-                        config.push(o);
+                if (file == 'users.json') {
+                    var usersFile = filedata.content
+                    if (usersFile) {
+                        users = JSON.parse(usersFile);
                     }
-                }
-                if (lang == 'CSS') {
+                } else if (lang == 'JavaScript' || lang == 'JSON' || lang == null) {
+                      var configFile = JSON.parse(filedata.content);
+                      if (configFile) {
+                          config.push(configFile);
+                      }
+                } else if (lang == 'CSS') {
                     var $custom_css = $('<style>');
                     $custom_css.text( filedata.content );
                     $('head').append( $custom_css );
                 }
             }
         }
+
         if (config.length > 0) {
             that.reset.call(that, config[0]);
         }
@@ -503,6 +509,10 @@
             }
 
             this.$el.addClass(this.ageClass(this.model.get('elapsed_time')));
+
+            if (users.length > 0 && $.inArray(this.model.get('user').login, users) == -1) {
+                this.$el.addClass('unimportant-user');
+            }
 
             if (this.model.comment.get('thumbsup')) {
                 this.$el.addClass("thumbsup");


### PR DESCRIPTION
- In the Core Team we have around fifty repos to keep track of pull requests on, but only nine or ten contributors directly in the team. To avoid everyone's PRs for every one of those repos coming up and
us struggling to scan the list to find relevant ones, we've added handling for a configurable `users` file optionally included in the gist. Using CSS, we've hidden PRs from users we don't care about.
- Test gist available at: https://gist.github.com/issyl0/70cf0c8f3d0b1ccd2f6e.
- We (@alicebartlett and I) didn't do this in the BackboneJS "way". Instead we put a global `users` array at the top of the file, but it was the way that we found that worked.