### PR TITLE
Add a screenshot of Fourth Wall to the README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -4,6 +4,8 @@
 
 Pure client-side pull request and build status monitor for Github repositories that use Travis.
 
+![Screenshot of Fourth Wall](https://cloud.githubusercontent.com/assets/355033/6211416/6341db4e-b5d1-11e4-99d2-57b80a400a41.png)
+
 ## How to use
 
 The project is hosted through Github pages:


### PR DESCRIPTION
- Thanks to Matt Bostock in
  https://github.com/alphagov/fourth-wall/issues/13 for suggesting
  this. I hope the link will keep working, given I commented on that
  Issue with an image and it uploaded it, and I'm using that same URL
  to save hosting it elsewhere...