### PR TITLE
Improved listing repos by github team

### DIFF
--- a/javascript/fetch-repos.js
+++ b/javascript/fetch-repos.js
@@ -128,13 +128,16 @@
 
   var fetchTeamId = function(team) {
     return FourthWall.fetchDefer({
-      url: team.baseUrl + '/orgs/' + team.org + '/teams',
+      // team.list results are paginated, try and get as many in the first page
+      // as possible to map slug-to-id (github max is 100 per-page)
+      url: team.baseUrl + '/orgs/' + team.org + '/teams?per_page=100',
       done: function (result) {
         for (var i = 0; i < result.length; i++) {
           if (result[i].slug === team.team) {
             return result[i].id;
           }
         }
+        throw "Couldn't map team '" + team.team + "' to an ID"
       }
     });
   };

--- a/javascript/fetch-repos.js
+++ b/javascript/fetch-repos.js
@@ -131,7 +131,7 @@
       url: team.baseUrl + '/orgs/' + team.org + '/teams',
       done: function (result) {
         for (var i = 0; i < result.length; i++) {
-          if (result[i].name === team.team) {
+          if (result[i].slug === team.team) {
             return result[i].id;
           }
         }


### PR DESCRIPTION
This had a couple of issues, 1 per commit, so thats the best way to review.

1/ Match on team slug, not name. The teams using this so far have names that are the same as their slug, but wasn't working for the custom formats team.

2/ Fetch more teams when mapping a team slug to ID, as the teams API call is paginated, and the custom formats team wasn't on the first page, and wasn't found.