### PR TITLE
[Semi-Breaking-Change] Support filtering PRs by team members

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -22,13 +22,13 @@ The following query parameters are required:
 
  At least one of:
  - `gist`: ID of the Gist containing the list of repositories to monitor.
- - `team`: Github organisation and team name to build the list of repositories in the form `{org}/{team}` (requires the [`read:org`](https://developer.github.com/v3/orgs/) permission).
+ - `team`: Github organisation and team name to build the list of repositories in the form `{org}/{team}` (requires the [`read:org`](https://developer.github.com/v3/orgs/) permission). (note, by default it will only show PRs by members of that team)
  - `file`: URL of a file in a Github repo that contains the list of repositories.
 
 Optional query parameters:
  - `listinterval`: Update interval for the list of monitored repos in seconds (default: 900)
  - `interval`: Update interval for monitored repos in seconds (default: 60)
- - `showallusers`: Show PRs from all users, even if config limits the users
+ - `showallusers`: Show PRs from all users, even if config limits the users.
 
 The Gist should contain one or more JSON files with this syntax:
 ```json

--- a/README.markdown
+++ b/README.markdown
@@ -28,6 +28,7 @@ The following query parameters are required:
 Optional query parameters:
  - `listinterval`: Update interval for the list of monitored repos in seconds (default: 900)
  - `interval`: Update interval for monitored repos in seconds (default: 60)
+ - `showallusers`: Show PRs from all users, even if config limits the users
 
 The Gist should contain one or more JSON files with this syntax:
 ```json

--- a/javascript/core.js
+++ b/javascript/core.js
@@ -117,6 +117,10 @@
     }
   };
 
+  FourthWall.showAllUsers = stripSlash(
+    FourthWall.getQueryVariable('show_all_users')
+  );
+
   FourthWall.gistId = stripSlash(
     FourthWall.getQueryVariable('gist')
   );

--- a/javascript/fetch-repos.js
+++ b/javascript/fetch-repos.js
@@ -122,6 +122,15 @@
           }));
         }
       });
+
+      FourthWall.fetchDefer({
+        url: team.baseUrl + "/teams/" + teamId + "/members",
+        done: function (result) {
+          FourthWall.importantUsers = result.map(function(item) {
+            return item.login
+          });
+        }
+      });
     });
     return d;
   };

--- a/javascript/pull-view.js
+++ b/javascript/pull-view.js
@@ -21,7 +21,7 @@
 
       this.$el.addClass(this.ageClass(this.model.get('elapsed_time')));
 
-      if (FourthWall.importantUsers.length > 0 && $.inArray(this.model.get('user').login, FourthWall.importantUsers) == -1) {
+      if (!FourthWall.showAllUsers && FourthWall.importantUsers.length > 0 && $.inArray(this.model.get('user').login, FourthWall.importantUsers) == -1) {
         this.$el.addClass('unimportant-user');
       }
 


### PR DESCRIPTION
**The Breaking Change**: Anyone using team-based config would need to add `&showallusers=1` to bring back PRs by non-team members.

Currently you can set a list of users in the Gist configuration
and only show PRs owned by those users. This is generally used to
limit PRs to members of a single team where they share repos with
other teams and want to focus on their changes.

To switch between filtering and not you need to edit the gist,
which more involved than a query param, especially as you normally
want the same repo list / styling / etc.

This also adds the filter-by-user behaviour to
team-based config, and as a default limiting PRs to members of
that team. This param gives an easy way to bring back the previous
behaviour.

Filtering for teams mirrors including `users.json` in gist-based config,
but is implicit from the GH team itself.

This will change the default behaviour, where team-based config
showed all PRs you'll now need to set the `showallusers` query
param to see PRs by non-team members.

I'd rather have not changed the default, but I want a param that
controls users set in JSON config, and from teams. It makes sense
that if gist-config sets users then they should be used without
needing to opt in, and I think teams are more widely using that
config vs team-based, so it's less disruptive to require those
using team-based config to add the parameter.

If this is contentious, then i'd be will to switch to opting-in
to user filtering instead, but i'd like to be able to get
team-based filtering in somehow.

CC @robyoung as a team-config user, and @edds as a gist-config user.