### PR TITLE
Fetch as many repos for a team as possible 

### DIFF
--- a/javascript/core.js
+++ b/javascript/core.js
@@ -87,6 +87,7 @@
       type: "GET",
       beforeSend: setupAuthentication(options.url),
       url: options.url,
+      data: options.data
     }).done(function(result) {
       d.resolve(options.done(result));
     }).fail(d.reject);

--- a/javascript/fetch-repos.js
+++ b/javascript/fetch-repos.js
@@ -111,7 +111,7 @@
     var d = $.Deferred();
     fetchTeamId(team).done(function(teamId) {
       FourthWall.fetchDefer({
-        url: team.baseUrl + "/teams/" + teamId + "/repos",
+        url: team.baseUrl + "/teams/" + teamId + "/repos?per_page=100",
         done: function (result) {
           d.resolve(result.map(function(item) {
             return {

--- a/javascript/fetch-repos.js
+++ b/javascript/fetch-repos.js
@@ -111,7 +111,8 @@
     var d = $.Deferred();
     fetchTeamId(team).done(function(teamId) {
       FourthWall.fetchDefer({
-        url: team.baseUrl + "/teams/" + teamId + "/repos?per_page=100",
+        url: team.baseUrl + "/teams/" + teamId + "/repos",
+        data: { per_page: 100 },
         done: function (result) {
           d.resolve(result.map(function(item) {
             return {
@@ -130,7 +131,8 @@
     return FourthWall.fetchDefer({
       // team.list results are paginated, try and get as many in the first page
       // as possible to map slug-to-id (github max is 100 per-page)
-      url: team.baseUrl + '/orgs/' + team.org + '/teams?per_page=100',
+      url: team.baseUrl + '/orgs/' + team.org + '/teams',
+      data: { per_page: 100 },
       done: function (result) {
         for (var i = 0; i < result.length; i++) {
           if (result[i].slug === team.team) {


### PR DESCRIPTION
By default the github API returns 30 items for a paginated set of
results. The repo list is paginated and on a team with more than
30 repos not all repos were shown

GH lets you request larger page sizes, up to 100, which won't
solve the problem forever, but makes it less likely we'll miss
repos when using team-based config.

:gift: **bonus refactor** :gift:: 

Support jQuery `data` option for query  parameters through 
`fetchDefer`.