### PR TITLE
Make filtering by user opt-in by param (+ for teams)

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -28,6 +28,7 @@ The following query parameters are required:
 Optional query parameters:
  - `listinterval`: Update interval for the list of monitored repos in seconds (default: 900)
  - `interval`: Update interval for monitored repos in seconds (default: 60)
+ - `filterusers`: Only show PRs from specific users, if set in config (default: false)
 
 The Gist should contain one or more JSON files with this syntax:
 ```json
@@ -43,8 +44,8 @@ You must make sure you set the language of the Gist to JSON as it will
 default to Text, which will not work.
 
 Optionally, the Gist can contain a JSON file named `users`, to list
-users the team cares about. Fourth Wall will then only display PRs
-across your tracked apps opened by these users. Syntax:
+users the team cares about. Fourth Wall can then display PRs
+across your tracked apps opened by these users, if the `filterusers` param is set. Syntax:
 ```json
 [
   "username0",

--- a/javascript/core.js
+++ b/javascript/core.js
@@ -118,11 +118,15 @@
     }
   };
 
+  FourthWall.filterUsers = !!stripSlash(
+    FourthWall.getQueryVariable('filterusers')
+  );
   FourthWall.gistId = stripSlash(
     FourthWall.getQueryVariable('gist')
   );
   FourthWall.fileUrl = stripSlash(
     FourthWall.getQueryVariable('file')
   );
+  FourthWall.importantUsers = [];
 
 })();

--- a/javascript/fetch-repos.js
+++ b/javascript/fetch-repos.js
@@ -76,7 +76,10 @@
               language = fileData.language;
           if (file == "users.json") {
             if (fileData.content) {
-              FourthWall.importantUsers = JSON.parse(fileData.content);
+              FourthWall.importantUsers = $.merge(
+                FourthWall.importantUsers,
+                JSON.parse(fileData.content)
+              );
             }
           } else if ($.inArray(language, ['JavaScript', 'JSON', null]) !== -1) {
             repos = JSON.parse(fileData.content);
@@ -121,6 +124,15 @@
               baseUrl: team.baseUrl + "/repos",
             };
           }));
+        }
+      });
+
+      FourthWall.fetchDefer({
+        url: team.baseUrl + "/teams/" + teamId + "/members",
+        done: function (result) {
+          result.forEach(function(member) {
+            FourthWall.importantUsers.push(member.login)
+          });
         }
       });
     });

--- a/javascript/pull-view.js
+++ b/javascript/pull-view.js
@@ -21,7 +21,7 @@
 
       this.$el.addClass(this.ageClass(this.model.get('elapsed_time')));
 
-      if (FourthWall.importantUsers.length > 0 && $.inArray(this.model.get('user').login, FourthWall.importantUsers) == -1) {
+      if (FourthWall.filterUsers && FourthWall.importantUsers.length > 0 && $.inArray(this.model.get('user').login, FourthWall.importantUsers) == -1) {
         this.$el.addClass('unimportant-user');
       }
 


### PR DESCRIPTION
A follow up to https://github.com/alphagov/fourth-wall/pull/38.

It switches the default, so filtering users is an opt in. This is a default
that encourages better behaviour, and few teams are actually using
it, so it should be the least disruptive.

(There used to be two commits, i accidentally smushed them, and it's 
too late in the day to be unpicking them  ¯\_(ツ)_/¯)

Currently you can set a list of users in the Gist configuration
and only show PRs owned by those users. This is generally used to
limit PRs to members of a single team where they share repos with
other teams and want to focus on their changes.

To switch between filtering and not you need to edit the gist,
which is more involved than a query param, especially as you
normally want the same repo list / styling / etc.

Prevoiusly if users were set in a gist then they would
automatically be used to filter PRs, however, after discussion
with Edds he convinced me that it's a bad default, we should
encourage being aware of other teams/contributors work on repos.

This doesn't remove the code behaviour, just changes the default
to promote better human behaviour. As this also allows you to
filter by users for team-based config, and having filtering on by
default would be even worse.

Initialise `FourthWall.importantUsers` as it may not be set by
either team config or gist config, as they can be used at the
same time.

Note: this makes the call to get team members even if filtering is
not used. This is it would be useful to use `importantUsers` to
highlight important PRs, without entirely ommiting others.

Note: Urgh, javascript array merging.