### PR TITLE
Add support for marking repositories as important

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -53,6 +53,11 @@ across your tracked apps opened by these users, if the `filterusers` param is se
 ]
 ```
 
+Optionally, entries may also contain ```"important": true``` to indicate that a
+repository is important.  This has an effect only when the `filterusers` param
+is set: PRs on important repositories will always be displayed, even when they
+weren't opened by one of the listed users.
+
 If the Gist contains a file with the language set to `CSS`, it will be injected
 into a `<style>` block in the document head, so you can override the default
 styling without having to fork this repo.

--- a/fourth-wall.css
+++ b/fourth-wall.css
@@ -74,7 +74,7 @@ body {
 #pulls li.age-old {
     background: #F47738;
 }
-#pulls li.unimportant-user {
+#pulls li.unimportant-user.unimportant-repo {
   display: none;
 }
 

--- a/javascript/fetch-repos.js
+++ b/javascript/fetch-repos.js
@@ -33,7 +33,10 @@
     if (repos2) {
       repos2.forEach(function(repo) {
         var found = result.some(function(testRepo) {
-          return _.isEqual(repo, testRepo);
+          return _.isEqual(
+            { userName: repo.userName, repo: repo.repo, baseUrl: repo.baseUrl || 'https://api.github.com/repos' },
+            { userName: testRepo.userName, repo: testRepo.repo, baseUrl: testRepo.baseUrl || 'https://api.github.com/repos' }
+          );
         });
         if (!found) {
           result.push(repo);

--- a/javascript/pull-view.js
+++ b/javascript/pull-view.js
@@ -25,6 +25,10 @@
         this.$el.addClass('unimportant-user');
       }
 
+      if (!this.model.collection.important) {
+        this.$el.addClass('unimportant-repo');
+      }
+
       if (this.model.comment.get('thumbsup')) {
         this.$el.addClass("thumbsup");
       }

--- a/javascript/pulls.js
+++ b/javascript/pulls.js
@@ -10,6 +10,7 @@
       this.baseUrl = options.baseUrl;
       this.userName = options.userName;
       this.repo = options.repo;
+      this.important = options.important;
     },
 
     url: function () {

--- a/javascript/repo.js
+++ b/javascript/repo.js
@@ -21,7 +21,8 @@
       this.pulls = new FourthWall.Pulls([], {
         baseUrl: this.get('baseUrl'),
         userName: this.get('userName'),
-        repo: this.get('repo')
+        repo: this.get('repo'),
+        important: this.get('important')
       });
 
       this.pulls.on('reset add remove', function () {


### PR DESCRIPTION
This is for use in conjunction with the "filterusers" parameter, to make
PRs on some repositories always be shown, even if not opened by one of
the specified users.

This allows us to have a wall which lists any PRs on repositories
"owned" by our team, together with any PRs on other repositories made by
team members.