### PR TITLE
Support multiple teams for a github instance.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -18,14 +18,18 @@ access token. To use the `team` parameter you will need to give the token
 the `read:org` permission.
 
 The following query parameters are required:
+
  - `token`: Your Github API token
 
- At least one of:
+At least one of:
+
  - `gist`: ID of the Gist containing the list of repositories to monitor.
  - `team`: Github organisation and team name to build the list of repositories in the form `{org}/{team}` (requires the [`read:org`](https://developer.github.com/v3/orgs/) permission).
+ - `team[]`: Given multiple times allows for more than one team to be used to build the list of repositories.
  - `file`: URL of a file in a Github repo that contains the list of repositories.
 
 Optional query parameters:
+
  - `listinterval`: Update interval for the list of monitored repos in seconds (default: 900)
  - `interval`: Update interval for monitored repos in seconds (default: 60)
  - `filterusers`: Only show PRs from specific users, if set in config (default: false)
@@ -87,4 +91,5 @@ An example enterprise repository.
 ```
 
 To load repositories from a team on an enterprise instance you must prefix the
-hostname to the team url parameter as with the token `<hostname>_team`.
+hostname to the team url parameter as with the token `<hostname>_team` (or
+`<hostname>_team[]` for multiple teams).

--- a/javascript/core.js
+++ b/javascript/core.js
@@ -11,7 +11,16 @@
       .split("&")
       .reduce( function(params, n) {
         n = n.split("=");
-        params[n[0]] = n[1];
+        var arrayKey = /^(.*)\[\]$/.exec(n[0]);
+        if (arrayKey) {
+          if (params[arrayKey[1]] instanceof Array) {
+            params[arrayKey[1]].push(n[1]);
+          } else {
+            params[arrayKey[1]] = [n[1]];
+          }
+        } else {
+          params[n[0]] = n[1];
+        }
         return params;
       }, {});
   };

--- a/javascript/core.js
+++ b/javascript/core.js
@@ -61,25 +61,33 @@
 
   FourthWall.getTeams = function() {
     var params = FourthWall.getQueryVariables();
-    return Object.keys(params).filter(function(key) {
+    var teams = [];
+    Object.keys(params).filter(function(key) {
       var match = key.match(/team$/);
       return match && match[0] == 'team';
-    }).map(function(key) {
+    }).forEach(function(key) {
       var hostname = key.match(/^(.*?)_?team$/)[1];
       if (hostname === "") {
         hostname = "api.github.com";
       }
-      var fullTeamName = stripSlash(params[key]).split('/');
-      if (fullTeamName.length !== 2) {
-        throw "Team name must contain a slash {org}/{team}";
+      var teamStrings = params[key];
+      if (! (teamStrings instanceof Array)) {
+        teamStrings = [teamStrings];
       }
-      return {
-        org: fullTeamName[0],
-        team: fullTeamName[1],
-        hostname: hostname,
-        baseUrl: getBaseUrlFromHostname(hostname),
-      };
+      teamStrings.forEach(function(teamStr) {
+        var fullTeamName = stripSlash(teamStr).split('/');
+        if (fullTeamName.length !== 2) {
+          throw "Team name must contain a slash {org}/{team}";
+        }
+        teams.push({
+          org: fullTeamName[0],
+          team: fullTeamName[1],
+          hostname: hostname,
+          baseUrl: getBaseUrlFromHostname(hostname),
+        });
+      });
     });
+    return teams;
   };
 
   function getBaseUrlFromHostname(hostname) {

--- a/spec/spec.fourth-wall.js
+++ b/spec/spec.fourth-wall.js
@@ -106,7 +106,7 @@ describe("Fourth Wall", function () {
         baseUrl: "https://api.github.com"
       };
       expect(teams.length).toBe(1);
-      expect(_.isEqual(teams[0], expected)).toEqual(true);
+      expect(teams[0]).toEqual(expected);
     });
 
     it("should return an array with a github enterprise team", function () {
@@ -120,7 +120,7 @@ describe("Fourth Wall", function () {
         hostname: "github.gds",
         baseUrl: "https://github.gds/api/v3"
       };
-      expect(_.isEqual(teams[0], expected)).toEqual(true);
+      expect(teams[0]).toEqual(expected);
     });
 
     it("should return an empty array if no teams are set", function() {

--- a/spec/spec.fourth-wall.js
+++ b/spec/spec.fourth-wall.js
@@ -127,6 +127,37 @@ describe("Fourth Wall", function () {
       expect(teams[0]).toEqual(expected);
     });
 
+    it("should handle multiple teams for a given instance", function() {
+      spyOn(FourthWall, "getQueryVariables").andReturn({"team": ["org1/team1", "org2/team2"], "github.gds_team": ["myorg/myteam", "otherorg/team2"]});
+      var teams = FourthWall.getTeams();
+
+      expect(teams.length).toBe(4);
+      expect(teams[0]).toEqual({
+        org: "org1",
+        team: "team1",
+        hostname: "api.github.com",
+        baseUrl: "https://api.github.com"
+      });
+      expect(teams[1]).toEqual({
+        org: "org2",
+        team: "team2",
+        hostname: "api.github.com",
+        baseUrl: "https://api.github.com"
+      });
+      expect(teams[2]).toEqual({
+        org: "myorg",
+        team: "myteam",
+        hostname: "github.gds",
+        baseUrl: "https://github.gds/api/v3"
+      });
+      expect(teams[3]).toEqual({
+        org: "otherorg",
+        team: "team2",
+        hostname: "github.gds",
+        baseUrl: "https://github.gds/api/v3"
+      });
+    });
+
     it("should return an empty array if no teams are set", function() {
       spyOn(FourthWall, "getQueryVariables").andReturn({"foo": "bar"});
       var teams = FourthWall.getTeams();

--- a/spec/spec.fourth-wall.js
+++ b/spec/spec.fourth-wall.js
@@ -22,6 +22,10 @@ describe("Fourth Wall", function () {
       var query_params = FourthWall.getQueryVariables();
       expect(query_params).toEqual({foo: 'bar', me: 'you'});
     });
+    it("should handle array parameters with [] keys", function () {
+      var query_params = FourthWall.getQueryVariables("?ref=gh-pages&token[]=nonsense&token[]=foo");
+      expect(query_params).toEqual({'ref': 'gh-pages', 'token': ['nonsense', 'foo']});
+    });
   });
   describe("getQueryVariable", function () {
     it("should get a query parameter from the provided query string", function () {


### PR DESCRIPTION
This adds support for array parameters in the URL so that it's possible to specify multiple teams for a given github instance (eg teams from 2 different github orgs).