### PR TITLE
Add ability to ignore WIP commits

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -33,6 +33,7 @@ Optional query parameters:
  - `listinterval`: Update interval for the list of monitored repos in seconds (default: 900)
  - `interval`: Update interval for monitored repos in seconds (default: 60)
  - `filterusers`: Only show PRs from specific users, if set in config (default: false)
+ - `ignore_wip`: Only show PRs which do not have a `[WIP]` tag in the title. Tag position is irrelevant.
 
 The Gist should contain one or more JSON files with this syntax:
 ```json

--- a/javascript/core.js
+++ b/javascript/core.js
@@ -49,6 +49,10 @@
     return token;
   };
 
+  FourthWall.ignoreWIP = function () {
+    return parseInt(FourthWall.getQueryVariable('ignore_wip') || 0);
+  };
+
   FourthWall.getTokenFromUrl = function (url) {
     var a = document.createElement('a');
     a.href = url;

--- a/javascript/list-view.js
+++ b/javascript/list-view.js
@@ -25,9 +25,13 @@
           model: model,
           list: this
         });
+        var ignoreWIP = FourthWall.ignoreWIP();
+        var isWIP = view.model.get('title').indexOf('[WIP]') >= 0;
         view.render();
-        view.$el.appendTo(this.$el);
-        this.lis.push(view);
+        if (!isWIP || (isWIP && !ignoreWIP)) {
+            view.$el.appendTo(this.$el);
+            this.lis.push(view);
+        }
       }, this);
       if (this.lis.length) {
         $('#all-quiet').hide();


### PR DESCRIPTION
## What

We have met the need, to ignore the WIP commits, in order to focus on actual PR that may be important.

This change, allows us to add an extra GET parameter, to the URL which then will be taken into consideration to hide WIP PRs.

The usage, has also been documented.

## How to review

- Peak over the code
- Check if docs make sense
- If you don't think I am trustworthy, open the app and add `ignore_wip=1` to the URL in order to ignore any `[WIP]` PRs

## Note

@alext has pointed out to me, that if the PR is un-flagged as `WIP`, it may not show immediately on the board. This may require more thought into it...