### PR TITLE
Look at review comments for approval

### DIFF
--- a/fourth-wall.css
+++ b/fourth-wall.css
@@ -82,7 +82,7 @@ body {
     background: #5c9317;
 }
 #pulls li.changes-requested {
-    background: #BF1E2D !important;
+    background: #BF1E2D;
 }
 #pulls li h2 {
     margin:0;

--- a/fourth-wall.css
+++ b/fourth-wall.css
@@ -81,6 +81,9 @@ body {
 #pulls li.thumbsup {
     background: #5c9317;
 }
+#pulls li.changes-requested {
+    background: #BF1E2D !important;
+}
 #pulls li h2 {
     margin:0;
 }

--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
 <script src="javascript/fetch-repos.js" type="text/javascript"></script>
 
 <script src="javascript/comment.js" type="text/javascript" charset="utf-8"></script>
+<script src="javascript/review-comment.js" type="text/javascript" charset="utf-8"></script>
 <script src="javascript/info.js" type="text/javascript"></script>
 <script src="javascript/list-items.js" type="text/javascript"></script>
 <script src="javascript/list-view.js" type="text/javascript"></script>

--- a/javascript/core.js
+++ b/javascript/core.js
@@ -1,7 +1,7 @@
 (function () {
   "use strict";
   window.FourthWall = window.FourthWall || {};
-  
+
   FourthWall.importantUsers = [];
 
   FourthWall.getQueryVariables = function(search) {
@@ -123,7 +123,7 @@
       var token = FourthWall.getTokenFromUrl(baseUrl);
       if (token !== false && token !== '') {
         xhr.setRequestHeader('Authorization', 'token ' + token);
-        xhr.setRequestHeader('Accept', 'application/vnd.github.v3+json');
+        xhr.setRequestHeader('Accept', 'application/vnd.github.black-cat-preview+json');
       }
     };
   };

--- a/javascript/list-items.js
+++ b/javascript/list-items.js
@@ -16,7 +16,7 @@
     },
 
     isThumbsUp: function (x) {
-      return x.comment.get('thumbsup');
+      return (x.comment.get('thumbsup') || x.reviewComment.get('approved'));
     },
 
     compare: function (f, a, b) {

--- a/javascript/list-items.js
+++ b/javascript/list-items.js
@@ -16,7 +16,7 @@
     },
 
     isThumbsUp: function (x) {
-      return (x.comment.get('thumbsup') || x.reviewComment.get('approved'));
+      return ((x.comment.get('thumbsup') || x.reviewComment.get('approved')) && !x.reviewComment.get('changesRequested'));
     },
 
     compare: function (f, a, b) {

--- a/javascript/pull-view.js
+++ b/javascript/pull-view.js
@@ -46,8 +46,14 @@
       if (this.model.comment.get('numComments')){
         commentCount = commentCount + this.model.comment.get('numComments');
       }
-      if (this.model.info.get('review_comments')){
-        commentCount = commentCount + this.model.info.get('review_comments');
+      
+      if (this.model.reviewComment.get('numComments')){
+        commentCount = commentCount + this.model.reviewComment.get('numComments');
+      }
+
+      var suffix = "";
+      if (commentCount !== 1) {
+        suffix = "s";
       }
 
       var assignee = "";

--- a/javascript/pull-view.js
+++ b/javascript/pull-view.js
@@ -29,14 +29,10 @@
         this.$el.addClass('unimportant-repo');
       }
 
-      if (this.model.comment.get('thumbsup') || this.model.reviewComment.get('approved')) {
-        if (!this.model.reviewComment.get('changesRequested')) {
-          this.$el.addClass("thumbsup");
-        }
-      }
-
       if (this.model.reviewComment.get('changesRequested')) {
         this.$el.addClass("changes-requested");
+      } else if (this.model.comment.get('thumbsup') || this.model.reviewComment.get('approved')) {
+        this.$el.addClass("thumbsup");
       }
 
       if (this.model.info.get('mergeable') === false){

--- a/javascript/pull-view.js
+++ b/javascript/pull-view.js
@@ -29,13 +29,8 @@
         this.$el.addClass('unimportant-repo');
       }
 
-      if (this.model.comment.get('thumbsup')) {
+      if (this.model.comment.get('thumbsup') || this.model.reviewComment.get('approved')) {
         this.$el.addClass("thumbsup");
-      }
-
-      var suffix = "";
-      if (this.model.comment.get('numComments') !== 1) {
-        suffix = "s";
       }
 
       if (this.model.info.get('mergeable') === false){

--- a/javascript/pull-view.js
+++ b/javascript/pull-view.js
@@ -30,7 +30,13 @@
       }
 
       if (this.model.comment.get('thumbsup') || this.model.reviewComment.get('approved')) {
-        this.$el.addClass("thumbsup");
+        if (!this.model.reviewComment.get('changesRequested')) {
+          this.$el.addClass("thumbsup");
+        }
+      }
+
+      if (this.model.reviewComment.get('changesRequested')) {
+        this.$el.addClass("changes-requested");
       }
 
       if (this.model.info.get('mergeable') === false){
@@ -46,7 +52,7 @@
       if (this.model.comment.get('numComments')){
         commentCount = commentCount + this.model.comment.get('numComments');
       }
-      
+
       if (this.model.reviewComment.get('numComments')){
         commentCount = commentCount + this.model.reviewComment.get('numComments');
       }

--- a/javascript/pull.js
+++ b/javascript/pull.js
@@ -6,12 +6,21 @@
     initialize: function () {
       this.set('repo', this.collection.repo);
       this.comment = new FourthWall.Comment();
+      this.reviewComment = new FourthWall.ReviewComment();
       this.comment.url = this.get('comments_url');
+      this.reviewComment.url = this.get('url') + '/reviews';
       this.on('change:comments_url', function () {
         this.comment.url = this.get('comments_url');
         this.comment.fetch();
       }, this);
+      this.on('change:url', function () {
+        this.reviewComment.url = this.get('url') + '/reviews';
+        this.reviewComment.fetch();
+      }, this);
       this.comment.on('change', function () {
+        this.trigger('change');
+      }, this);
+      this.reviewComment.on('change', function () {
         this.trigger('change');
       }, this);
       this.status = new FourthWall.Status({
@@ -44,6 +53,7 @@
     fetch: function () {
       this.status.fetch();
       this.comment.fetch();
+      this.reviewComment.fetch();
       this.info.fetch();
     },
 

--- a/javascript/review-comment.js
+++ b/javascript/review-comment.js
@@ -4,20 +4,61 @@
 
   FourthWall.ReviewComment = Backbone.Model.extend({
     parse: function (response) {
-      var approved = response.some(function(comment) {
-        return comment.state === 'APPROVED'
-      });
-      var changesRequested = response.some(function(comment) {
-        return comment.state === 'CHANGES_REQUESTED'
-      });
+      var numComments = response.length;
+      var approved = false;
+      var changesRequested = false;
+      var commentsByUser = this.splitCommentsByUser(response);
+      var statuses = this.getStatus(commentsByUser);
+      approved = statuses[0];
+      changesRequested = statuses[1]
+
       return {
         approved: approved,
         changesRequested: changesRequested,
-        numComments: response.length
+        numComments: numComments
       }
     },
+
     fetch: function() {
       return FourthWall.overrideFetch.call(this, this.url);
+    },
+
+    splitCommentsByUser: function(response) {
+      var commentsByUser = []
+      var single_user_comments = []
+      while (response[0]) {
+        single_user_comments.push(response.shift())
+        response.forEach(function(comment, index) {
+          if (comment.user.id === single_user_comments[0].user.id) {
+            single_user_comments.push(comment);
+          }
+        })
+        for (var i = response.length -1; i >= 0; i-- ) {
+          if (response[i].user.id === single_user_comments[0].user.id) {
+            response.splice(i, 1)
+          };
+        }
+        commentsByUser.push(single_user_comments);
+        single_user_comments = [];
+      };
+      return commentsByUser
+    },
+    
+    getStatus: function(commentsByUser) {
+      var approved = false;
+      var changesRequested = false;
+      commentsByUser.forEach(function (comments) {
+        for (var x = comments.length -1; x >= 0; x-- ) {
+          if (comments[x].state === 'APPROVED') {
+            approved = true;
+            break;
+          } else if (comments[x].state === 'CHANGES_REQUESTED') {
+            changesRequested = true;
+            break;
+          };
+        }
+      });
+      return [approved, changesRequested];
     }
   });
 }());

--- a/javascript/review-comment.js
+++ b/javascript/review-comment.js
@@ -1,0 +1,19 @@
+(function () {
+  "use strict";
+  window.FourthWall = window.FourthWall || {};
+
+  FourthWall.ReviewComment = Backbone.Model.extend({
+    parse: function (response) {
+      var approved = response.some(function(comment) {
+        return comment.state === 'APPROVED'
+      });
+      return {
+        approved: approved,
+        numComments: response.length
+      }
+    },
+    fetch: function() {
+      return FourthWall.overrideFetch.call(this, this.url);
+    }
+  });
+}());

--- a/javascript/review-comment.js
+++ b/javascript/review-comment.js
@@ -7,8 +7,12 @@
       var approved = response.some(function(comment) {
         return comment.state === 'APPROVED'
       });
+      var changesRequested = response.some(function(comment) {
+        return comment.state === 'CHANGES_REQUESTED'
+      });
       return {
         approved: approved,
+        changesRequested: changesRequested,
         numComments: response.length
       }
     },

--- a/spec/index.html
+++ b/spec/index.html
@@ -20,6 +20,7 @@
   <script src="../javascript/core.js" type="text/javascript"></script>
   <script src="../javascript/fetch-repos.js" type="text/javascript"></script>
   <script src="../javascript/comment.js" type="text/javascript"></script>
+  <script src="../javascript/review-comment.js" type="text/javascript"></script>
   <script src="../javascript/info.js" type="text/javascript"></script>
   <script src="../javascript/list-items.js" type="text/javascript"></script>
   <script src="../javascript/list-view.js" type="text/javascript"></script>

--- a/spec/spec.fourth-wall.js
+++ b/spec/spec.fourth-wall.js
@@ -283,6 +283,7 @@ describe("Fourth Wall", function () {
       var pull;
       beforeEach(function() {
         spyOn(FourthWall.Comment.prototype, "fetch");
+        spyOn(FourthWall.ReviewComment.prototype, "fetch");
         spyOn(FourthWall.Status.prototype, "fetch");
         spyOn(FourthWall.Info.prototype, "fetch");
         pull = new FourthWall.Pull({
@@ -296,6 +297,10 @@ describe("Fourth Wall", function () {
         expect(pull.comment instanceof FourthWall.Comment).toBe(true);
       });
 
+      it("instantiates an internal ReviewComment model", function () {
+        expect(pull.reviewComment instanceof FourthWall.ReviewComment).toBe(true);
+      });
+
       it("triggers a change when the comment changes", function () {
         var changed = false;
         pull.on('change', function () {
@@ -305,15 +310,35 @@ describe("Fourth Wall", function () {
         expect(changed).toBe(true);
       });
 
+      it("triggers a change when the review-comment changes", function () {
+        var changed = false;
+        pull.on('change', function () {
+          changed = true;
+        });
+        pull.reviewComment.set('foo', 'bar');
+        expect(changed).toBe(true);
+      });
+
       it("fetches new comment data when the comment URL changes", function () {
         pull.set('comments_url', 'foo');
         expect(pull.comment.url).toEqual('foo');
         expect(pull.comment.fetch).toHaveBeenCalled();
       });
 
+      it("fetches new review comment data when the review comment URL changes", function () {
+        pull.set('url', 'foo');
+        expect(pull.reviewComment.url).toEqual('foo/reviews');
+        expect(pull.reviewComment.fetch).toHaveBeenCalled();
+      });
+
       it("fetches new comment data when pull data has been fetched", function () {
         pull.fetch()
         expect(pull.comment.fetch).toHaveBeenCalled();
+      });
+
+      it("fetches new review comment data when pull data has been fetched", function () {
+        pull.fetch()
+        expect(pull.reviewComment.fetch).toHaveBeenCalled();
       });
 
       it("instantiates an internal Status model", function () {
@@ -410,7 +435,7 @@ describe("Fourth Wall", function () {
         repo.pulls.reset();
         var items = new FourthWall.ListItems([], {
           repos: new FourthWall.Repos([
-            
+
           ])
         });
       });


### PR DESCRIPTION
Currently fourth wall only turns a PR green if a normal comment has a thumbs up. Github now has review comments, which are different. 

In a review you can mark the PR as approved. This PR adds a new backbone model which checks review comments for the `APPROVED` state. If found the `thumbsup` class is added to the pull-view, in the same way that is done for a normal comment with a thumbup.