### PR TITLE
Reduce space taken by WIP PRs.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -33,7 +33,7 @@ Optional query parameters:
  - `listinterval`: Update interval for the list of monitored repos in seconds (default: 900)
  - `interval`: Update interval for monitored repos in seconds (default: 60)
  - `filterusers`: Only show PRs from specific users, if set in config (default: false)
- - `wiphandling`: Specify treatment for PRs which have a `WIP` tag in the
+ - `wiphandling`: Specify treatment for PRs which have a `WIP` or `DO NOT MERGE` tag in the
    title. Set to `small` to reduce the amount of information shown for these so
    they take up less space.
 

--- a/README.markdown
+++ b/README.markdown
@@ -33,9 +33,9 @@ Optional query parameters:
  - `listinterval`: Update interval for the list of monitored repos in seconds (default: 900)
  - `interval`: Update interval for monitored repos in seconds (default: 60)
  - `filterusers`: Only show PRs from specific users, if set in config (default: false)
- - `wiphandling`: Specify treatment for PRs which have a `WIP` or `DO NOT MERGE` tag in the
-   title. Set to `small` to reduce the amount of information shown for these so
-   they take up less space.
+ - `wiphandling`: Specify treatment for PRs which have a `WIP` or `DO NOT
+   MERGE` tag in the title. By default these are shown in a reduced manner. Set
+   this param to `none` disable this and have them display like any other PRs.
 
 The Gist should contain one or more JSON files with this syntax:
 ```json

--- a/README.markdown
+++ b/README.markdown
@@ -33,6 +33,9 @@ Optional query parameters:
  - `listinterval`: Update interval for the list of monitored repos in seconds (default: 900)
  - `interval`: Update interval for monitored repos in seconds (default: 60)
  - `filterusers`: Only show PRs from specific users, if set in config (default: false)
+ - `wiphandling`: Specify treatment for PRs which have a `WIP` tag in the
+   title. Set to `small` to reduce the amount of information shown for these so
+   they take up less space.
 
 The Gist should contain one or more JSON files with this syntax:
 ```json

--- a/fourth-wall.css
+++ b/fourth-wall.css
@@ -94,6 +94,29 @@ body {
   color: white;
   text-decoration: none;
 }
+
+#pulls li.wip {
+  padding-left: 10px;
+  padding-right: 10px;
+  min-height: 50px;
+  background: #505050;
+}
+#pulls li.wip .avatar,
+#pulls li.wip .status,
+#pulls li.wip .elapsed-time,
+#pulls li.wip .comments {
+  display: none;
+}
+#pulls li.wip h2,
+#pulls li.wip p {
+  display: inline-block;
+  clear: none;
+}
+#pulls li.wip p {
+  padding-top: 0.2em;
+  padding-left: 0.5em;
+}
+
 #all-quiet {
     color: #b7b7b7;
     font-size:3em;

--- a/javascript/core.js
+++ b/javascript/core.js
@@ -146,7 +146,7 @@
   );
   FourthWall.importantUsers = [];
 
-  FourthWall.wipHandling = (FourthWall.getQueryVariable('wiphandling') || 'none');
+  FourthWall.wipHandling = (FourthWall.getQueryVariable('wiphandling') || 'small');
 
   FourthWall.wipStrings = ['WIP', 'DO NOT MERGE'];
 })();

--- a/javascript/core.js
+++ b/javascript/core.js
@@ -146,4 +146,5 @@
   );
   FourthWall.importantUsers = [];
 
+  FourthWall.wipHandling = (FourthWall.getQueryVariable('wiphandling') || 'none');
 })();

--- a/javascript/core.js
+++ b/javascript/core.js
@@ -147,4 +147,6 @@
   FourthWall.importantUsers = [];
 
   FourthWall.wipHandling = (FourthWall.getQueryVariable('wiphandling') || 'none');
+
+  FourthWall.wipStrings = ['WIP', 'DO NOT MERGE'];
 })();

--- a/javascript/pull-view.js
+++ b/javascript/pull-view.js
@@ -35,9 +35,13 @@
         this.$el.addClass("thumbsup");
       }
 
-      this.wip = (this.model.get('title').indexOf('WIP') >= 0);
-      if (FourthWall.wipHandling == 'small' && this.wip) {
-        this.$el.addClass("wip");
+      if (FourthWall.wipHandling == 'small') {
+        for (var i=0; i < FourthWall.wipStrings.length; i++) {
+          if (this.model.get('title').indexOf(FourthWall.wipStrings[i]) >= 0) {
+            this.$el.addClass("wip");
+            break;
+          }
+        }
       }
 
       if (this.model.info.get('mergeable') === false){

--- a/javascript/pull-view.js
+++ b/javascript/pull-view.js
@@ -35,6 +35,11 @@
         this.$el.addClass("thumbsup");
       }
 
+      this.wip = (this.model.get('title').indexOf('WIP') >= 0);
+      if (FourthWall.wipHandling == 'small' && this.wip) {
+        this.$el.addClass("wip");
+      }
+
       if (this.model.info.get('mergeable') === false){
         var statusString = '<p class="status not-mergeable">No auto merge</p>';
       } else if (this.model.status.get('state')){


### PR DESCRIPTION
In order to prevent WIP PRs taking up lots of space on a board, thereby
reducing the amount of space for PRs ready for review, this adds an
option to have them show only the repo, and title lines on a single
line. It also sets the background colour to dark grey to de-emphasise
them a bit.

Before:

![image](https://cloud.githubusercontent.com/assets/5560/22202712/45b205f0-e161-11e6-9724-aa9070bf494e.png)

After:

![image](https://cloud.githubusercontent.com/assets/5560/22202715/4d2efe82-e161-11e6-893a-4538e68447b9.png)