### PR TITLE
Fix comment count suffix when there are review comments.

### DIFF
--- a/javascript/pull-view.js
+++ b/javascript/pull-view.js
@@ -49,9 +49,9 @@
       if (this.model.info.get('review_comments')){
         commentCount = commentCount + this.model.info.get('review_comments');
       }
-      var suffix = "";
+      var commentCountSuffix = "";
       if (commentCount !== 1) {
-        suffix = "s";
+        commentCountSuffix = "s";
       }
 
       var assignee = "";
@@ -77,7 +77,7 @@
         this.model.get('number'),
         ')',
         '</a>' + assignee + '</p>',
-        '<p class="comments"> ' + commentCount + " comment" + suffix + '</p>',
+        '<p class="comments"> ' + commentCount + " comment" + commentCountSuffix + '</p>',
       ].join(''));
     },
 

--- a/javascript/pull-view.js
+++ b/javascript/pull-view.js
@@ -33,11 +33,6 @@
         this.$el.addClass("thumbsup");
       }
 
-      var suffix = "";
-      if (this.model.comment.get('numComments') !== 1) {
-        suffix = "s";
-      }
-
       if (this.model.info.get('mergeable') === false){
         var statusString = '<p class="status not-mergeable">No auto merge</p>';
       } else if (this.model.status.get('state')){
@@ -53,6 +48,10 @@
       }
       if (this.model.info.get('review_comments')){
         commentCount = commentCount + this.model.info.get('review_comments');
+      }
+      var suffix = "";
+      if (commentCount !== 1) {
+        suffix = "s";
       }
 
       var assignee = "";


### PR DESCRIPTION
We had an issue where the board would display "6 comment" without the
correct pluralisation. This was for a PR that has a single comment, and
5 "review comments", which are separate in the Github API. The suffix
was being calculated based on ordinary comments only.