### PR TITLE
Monitor default branch instead of master

### DIFF
--- a/javascript/fetch-repos.js
+++ b/javascript/fetch-repos.js
@@ -125,6 +125,7 @@
               repo: item.name,
               userName: item.owner.login,
               baseUrl: team.baseUrl + "/repos",
+              defaultBranch: item.default_branch,
             };
           }));
         }

--- a/javascript/master-status.js
+++ b/javascript/master-status.js
@@ -9,7 +9,7 @@
         this.get('userName'),
         this.get('repo'),
         'statuses',
-        'master'
+        this.get('defaultBranch')
       ].join('/');
     }
   });

--- a/javascript/repo.js
+++ b/javascript/repo.js
@@ -11,7 +11,8 @@
       this.master = new FourthWall.MasterStatus({
         baseUrl: this.get('baseUrl'),
         userName: this.get('userName'),
-        repo: this.get('repo')
+        repo: this.get('repo'),
+        defaultBranch: this.get('defaultBranch') || 'master'
       });
 
       this.master.on('change:failed', function () {


### PR DESCRIPTION
For some repos, the default branch is set to something other than
"master". This updates the master status tracking functionality to track
whatever the default branch is set to in Github instead of being hardcoded to
"master".

This is only supported when fetching repos by team at the moment as
that's currently the only part of the code that fetches the repo
information from Github - the gist and file methods get all the repo data
they need from the JSON data in the files.