### PR TITLE
Added 'hide' as an option for wiphandling parameter

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -33,9 +33,12 @@ Optional query parameters:
  - `listinterval`: Update interval for the list of monitored repos in seconds (default: 900)
  - `interval`: Update interval for monitored repos in seconds (default: 60)
  - `filterusers`: Only show PRs from specific users, if set in config (default: false)
- - `wiphandling`: Specify treatment for PRs which have a `WIP` or `DO NOT
+ - `wiphandling`: Specify treatment for WIP PRs; those which have a `WIP` or `DO NOT
    MERGE` tag in the title. By default these are shown in a reduced manner. Set
-   this param to `none` disable this and have them display like any other PRs.
+   this param to:
+    - _`none`_: display WIP PR's like any other PRs
+    - _`small`_ or unset: show WIP PR's in a reduced manner *default behaviour*
+    - _`hide`_: hide WIP PR's completely
 
 The Gist should contain one or more JSON files with this syntax:
 ```json

--- a/javascript/pull-view.js
+++ b/javascript/pull-view.js
@@ -42,6 +42,13 @@
             break;
           }
         }
+      } else if (FourthWall.wipHandling == 'hide') {
+        for (var i=0; i < FourthWall.wipStrings.length; i++) {
+          if (this.model.get('title').indexOf(FourthWall.wipStrings[i]) >= 0) {
+            this.$el.hide()
+            break;
+          }
+        }
       }
 
       if (this.model.info.get('mergeable') === false){


### PR DESCRIPTION
# Added 'hide' as an option for `wiphandling` parameter

## What
* Added 'hide' option to `wiphandling` query parameter which will $.hide() any WIP PRs. Edited: _javascript/pull-view.js_
* Updated Readme accordingly. Edited: _readme.markdown_