### PR TITLE
Treat PRs with a “REVIEW ONLY” tag in the title as WIP PRs

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -33,9 +33,9 @@ Optional query parameters:
  - `listinterval`: Update interval for the list of monitored repos in seconds (default: 900)
  - `interval`: Update interval for monitored repos in seconds (default: 60)
  - `filterusers`: Only show PRs from specific users, if set in config (default: false)
- - `wiphandling`: Specify treatment for WIP PRs; those which have a `WIP` or `DO NOT
-   MERGE` tag in the title. By default these are shown in a reduced manner. Set
-   this param to:
+ - `wiphandling`: Specify treatment for WIP PRs; those which have a `WIP`, `DO NOT
+   MERGE` or `REVIEW ONLY` tag in the title. By default these are shown in a reduced
+   manner. Set this param to:
     - _`none`_: display WIP PR's like any other PRs
     - _`small`_ or unset: show WIP PR's in a reduced manner *default behaviour*
     - _`hide`_: hide WIP PR's completely

--- a/javascript/core.js
+++ b/javascript/core.js
@@ -148,5 +148,5 @@
 
   FourthWall.wipHandling = (FourthWall.getQueryVariable('wiphandling') || 'small');
 
-  FourthWall.wipStrings = ['WIP', 'DO NOT MERGE'];
+  FourthWall.wipStrings = ['WIP', 'DO NOT MERGE', 'REVIEW ONLY'];
 })();


### PR DESCRIPTION
In the GOV.UK Pay team, people are forever putting “REVIEW ONLY” in the title of their PRs then getting sad when Fourth Wall doesn’t treat them as WIP PRs.

Usually someone will remind them in Slack to use “WIP” or “DO NOT MERGE” instead. But old habits die hard and they forget by the next time and create another “REVIEW ONLY” PR.

The end result is that a large portion of our Slack chatter is team members schooling their colleagues on how to tag WIP PRs correctly. It’s got to the point now where we’re considering writing a Slack bot to do the chastising for us.

This fixes the problem forever by treating “REVIEW ONLY” the same as  “WIP” and “DO NOT MERGE”.