### PR TITLE
Add ability to filter displayed repos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 TEST*.xml
+.idea

--- a/README.markdown
+++ b/README.markdown
@@ -39,6 +39,9 @@ Optional query parameters:
     - _`none`_: display WIP PR's like any other PRs
     - _`small`_ or unset: show WIP PR's in a reduced manner *default behaviour*
     - _`hide`_: hide WIP PR's completely
+ - `filterrepo`: Specify a repository name you wish to exclude from displayed PRs
+ - `filterrepo[]`: Given multiple times allows for more than one repository to be excluded
+
 
 The Gist should contain one or more JSON files with this syntax:
 ```json

--- a/javascript/core.js
+++ b/javascript/core.js
@@ -138,6 +138,9 @@
   FourthWall.filterUsers = !!stripSlash(
     FourthWall.getQueryVariable('filterusers')
   );
+
+  FourthWall.filteredRepos = (FourthWall.getQueryVariable('filteredrepos') || '').split(',').map(stripSlash);
+
   FourthWall.gistId = stripSlash(
     FourthWall.getQueryVariable('gist')
   );

--- a/javascript/core.js
+++ b/javascript/core.js
@@ -139,7 +139,11 @@
     FourthWall.getQueryVariable('filterusers')
   );
 
-  FourthWall.filteredRepos = (FourthWall.getQueryVariable('filteredrepos') || '').split(',').map(stripSlash);
+  //to deal with fact that query var could be string or array,
+  // put query var in array and then flatten it all out
+  var repos = [FourthWall.getQueryVariable('filterrepo') || ''];
+  FourthWall.filterRepos = [].concat.apply([], repos)
+    .map(stripSlash);
 
   FourthWall.gistId = stripSlash(
     FourthWall.getQueryVariable('gist')

--- a/javascript/fetch-repos.js
+++ b/javascript/fetch-repos.js
@@ -22,6 +22,11 @@
     var d = $.Deferred();
     $.when.apply(null, promises).done(function() {
       var allRepos = [].reduce.call(arguments, FetchRepos.mergeRepoArrays, []);
+
+      allRepos = allRepos.filter(function(repo) {
+        return FourthWall.filteredRepos.indexOf(repo.repo) === -1;
+      });
+
       d.resolve(allRepos);
     });
     return d;

--- a/javascript/fetch-repos.js
+++ b/javascript/fetch-repos.js
@@ -24,7 +24,7 @@
       var allRepos = [].reduce.call(arguments, FetchRepos.mergeRepoArrays, []);
 
       allRepos = allRepos.filter(function(repo) {
-        return FourthWall.filteredRepos.indexOf(repo.repo) === -1;
+        return FourthWall.filterRepos.indexOf(repo.repo) === -1;
       });
 
       d.resolve(allRepos);


### PR DESCRIPTION
Some GDS repos are linked to a large number of teams,
and thus show up on all those teams' fourth walls e.g.
`gds-tech-learning-pathway`. This commit adds functionality
to enable filtering of displayed repos using a comma separated
query param, to allow teams to only see repos they are
actively concerned with.

Usage:
`https://alphagov.github.io/fourth-wall/?token=my-big-token&team=alphagov/my-big-team&fiteredrepos=my-undesired-repo-1,my-undesired-repo-2`

I would have written some tests, but have neither time nor guile
enough to figure out how to run them. There's no guidance on this,
and no package.json to manage test dependencies. So trust me, this works.
Alternatively, check it locally before approving.