### PR TITLE
Stop treating 👍 as approval

### DIFF
--- a/javascript/comment.js
+++ b/javascript/comment.js
@@ -4,14 +4,7 @@
 
   FourthWall.Comment = Backbone.Model.extend({
     parse: function (response) {
-      var thumbsup = response.some(function(comment) {
-        var checkFor = ["👍", ":+1:", ":thumbsup:"];
-        return checkFor.some(function(check) {
-          return comment.body.indexOf(check) != -1;
-        });
-      });
       return {
-        thumbsup: thumbsup,
         numComments: response.length
       };
     },

--- a/javascript/list-items.js
+++ b/javascript/list-items.js
@@ -16,7 +16,7 @@
     },
 
     isThumbsUp: function (x) {
-      return ((x.comment.get('thumbsup') || x.reviewComment.get('approved')) && !x.reviewComment.get('changesRequested'));
+      return (x.reviewComment.get('approved') && !x.reviewComment.get('changesRequested'));
     },
 
     compare: function (f, a, b) {

--- a/javascript/pull-view.js
+++ b/javascript/pull-view.js
@@ -31,7 +31,7 @@
 
       if (this.model.reviewComment.get('changesRequested')) {
         this.$el.addClass("changes-requested");
-      } else if (this.model.comment.get('thumbsup') || this.model.reviewComment.get('approved')) {
+      } else if (this.model.reviewComment.get('approved')) {
         this.$el.addClass("thumbsup");
       }
 


### PR DESCRIPTION
The use of thumbs-up to indicate approval of a pull request predates [Github’s own pull request review functionality](https://help.github.com/articles/about-pull-request-reviews/).

We should stop using a comment containing 👍 to indicate approval because:
- Github pull request reviews are more discoverable – there’s no special syntax to learn
- using a 👍 is ambiguous for someone not using the Fourth Wall tool
- there might be a time when you want to use a 👍 _without_ implicitly approving the whole pull request