### PR TITLE
Fix HTTP logic and add ability to accept extra scopes.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -41,6 +41,7 @@ Optional query parameters:
     - _`hide`_: hide WIP PR's completely
  - `filterrepo`: Specify a repository name you wish to exclude from displayed PRs
  - `filterrepo[]`: Given multiple times allows for more than one repository to be excluded
+ - `extra_scopes`: A comma separated list of extra scopes that your token requires
 
 
 The Gist should contain one or more JSON files with this syntax:
@@ -118,6 +119,7 @@ Required scopes:
 Optional scopes:
 
 - `read:org` is required if you are using the `team` query parameter mentioned above.
+- `repo` is needed if you need to give fourth-wall access to private repositories, this must be enabled using the `extra_scopes` query parameter documented above.
 
 Any other allowed scopes on the token will cause Fourth Wall to be unusable
 (due to an alert) until the token scopes have been fixed. This is a feature not a bug.

--- a/javascript/preflight.js
+++ b/javascript/preflight.js
@@ -15,7 +15,11 @@ function runPreFlightChecks() {
   // - Make a request to the github rate limit endpoint
   //   (This will not affect the rate limit)
   // - Check what scopes we have access to
-  const token             = new FourthWall.getQueryVariables().token,
+  const queryVars         = new FourthWall.getQueryVariables(),
+        token             = queryVars.token,
+        extraScopes       = (queryVars.extra_scopes || '').split(',').filter(
+          function(scope) { return scope.length > 0 }
+        ),
         ghUrl             = 'https://api.github.com/rate_limit',
         authGhUrl         = ghUrl + '?access_token=' + token;
 
@@ -24,8 +28,10 @@ function runPreFlightChecks() {
     .then(function (headers)  { return headers.get('x-oauth-scopes')  })
     .then(function (scopes)   { return scopes.split(', '); })
     .then(function (scopes)   {
-      const allowedScopes = ['repo:status', 'repo_deployment', 'read:org'];
-      let   badScopes = scopes.filter(function(scope) {
+      const allowedScopes = [
+        'repo:status', 'repo_deployment', 'read:org'
+      ].concat(extraScopes);
+      let badScopes = scopes.filter(function(scope) {
         return allowedScopes.indexOf(scope) < 0;
       });
 

--- a/javascript/preflight.js
+++ b/javascript/preflight.js
@@ -1,7 +1,7 @@
 function runPreFlightChecks() {
   const isHttp      = window.location.protocol == 'http:',
         isLocalhost = window.location.hostname == 'localhost'
-        isUnsafe    = !(isHttp && isLocalhost);
+        isUnsafe    = !isHttp || !(isHttp && isLocalhost);
 
   if (isUnsafe) {
     const isHttpMessage = [


### PR DESCRIPTION
HTTP logic was broken (mb)

If someone wants to give their token access to private repos they can now do so using `extra_scopes` query param (comma separated) (e.g. `&extra_scopes=repo`).

Related to @edds comment on #59 