### PR TITLE
Remove reload for bad scopes

### DIFF
--- a/javascript/preflight.js
+++ b/javascript/preflight.js
@@ -41,12 +41,10 @@ function runPreFlightChecks() {
               'You have the following unnecessary scopes: <',
               badScopesString,
               '>; these scopes should be removed.',
-              'Clicking accept will reload this page.',
               'Reloading the page will show this message unless the scopes are correct.',
             ].join(' ');
 
         alert(badScopesMessage);
-        window.location.reload(true);
       }
     });
 }


### PR DESCRIPTION
This breaks the application for anyone using it with private repos, because (as far as I can work out) the `repo` scope is required to interact with private repos.

Removing the reload will keep the warning but allow the page to work.