### PR TITLE
Add connectivity check

### DIFF
--- a/fourth-wall.css
+++ b/fourth-wall.css
@@ -123,6 +123,21 @@ body {
     margin:1em;
 }
 
+#no-connectivity {
+    position: fixed;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    right: 0;
+    display: none;
+    justify-content: center;
+    align-items: center;
+    background-color: rgba(32, 32, 32, 0.85);
+    color: #b7b7b7;
+    font-size:3em;
+    font-family: monospace;
+}
+
 .elapsed-time {
     line-height: 110%;
     font-size: 1.5em;

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
 <body>
 <ul id="pulls"></ul>
 <p id="all-quiet">No open pull requests.</p>
+<div id="no-connectivity">&#x1f4f6; no connectivity</div>
 
 <script src="javascript/vendor/jquery-2.0.0.min.js" type="text/javascript"></script>
 <script src="javascript/vendor/moment-2.0.0.min.js" type="text/javascript"></script>
@@ -16,6 +17,7 @@
 <script src="javascript/vendor/backbone-1.0.0.min.js" type="text/javascript"></script>
 <script src="javascript/core.js" type="text/javascript"></script>
 <script src="javascript/preflight.js" type="text/javascript"></script>
+<script src="javascript/connectivity.js" type="text/javascript"></script>
 <script src="javascript/fetch-repos.js" type="text/javascript"></script>
 
 <script src="javascript/comment.js" type="text/javascript" charset="utf-8"></script>

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 $(document).ready(function() {
     runPreFlightChecks();
+    runConnectivityChecks();
 
     var repos = new FourthWall.Repos();
     var items = new FourthWall.ListItems([], {

--- a/javascript/connectivity.js
+++ b/javascript/connectivity.js
@@ -1,0 +1,11 @@
+function updateConnectivityStatus() {
+  let display = navigator.onLine ? 'none' : 'flex';
+  document.querySelector('#no-connectivity').style.display = display;
+}
+
+function runConnectivityChecks() {
+  updateConnectivityStatus(true);
+
+  window.addEventListener('online',  updateConnectivityStatus);
+  window.addEventListener('offline', updateConnectivityStatus);
+}


### PR DESCRIPTION
Commit message
--

```
Fixes #68

When a dashboard is offline then we cannot check the status of PRs. This
is unideal.

solo @tlwr
```

What
--

Adds a connectivity indicator using emoji and `navigator.onLine`

![screen shot 2018-12-18 at 00 04 11](https://user-images.githubusercontent.com/1482692/50123421-7d0ea480-0258-11e9-9d94-41edde08690f.png)

Why
--

So we are easily able to see when our dashboards aren't able to reflect reality

---

See #68 