### PR TITLE
Fix the PhantomJS test error

### DIFF
--- a/spec/lib/phantomjs-testrunner.js
+++ b/spec/lib/phantomjs-testrunner.js
@@ -1,5 +1,6 @@
 // Verify arguments
-if (phantom.args.length === 0) {
+var system = require('system');
+if (system.args.length === 1) {
     console.log("Simple JasmineBDD test runner for phantom.js");
     console.log("Usage: phantomjs-testrunner.js url_to_runner.html");
     console.log("Accepts http:// and file:// urls");
@@ -8,7 +9,7 @@ if (phantom.args.length === 0) {
     phantom.exit(2);
 }
 else {
-    var args = phantom.args;
+    var args = system.args;
     var pages = [], page, address, resultsKey, i, l;
 
     var setupPageFn = function(p, k) {
@@ -18,7 +19,7 @@ else {
         };
     };
 
-    for (i = 0, l = args.length; i < l; i++) {
+    for (i = 1, l = args.length; i < 2; i++) {
         address = args[i];
         console.log("Loading " + address);
 


### PR DESCRIPTION
- The tests for PR 73 were failing due to:

  ```
  $ sh spec/testrunner.sh
    Serving HTTP on 0.0.0.0 port 8000 ...
    TypeError: undefined is not an object (evaluating 'phantom.args.length')
    phantomjs://code/phantomjs-testrunner.js:2 in global code
  ```