### PR TITLE
Avv9sRJv: Fix GitHub deprecation warning

### DIFF
--- a/javascript/preflight.js
+++ b/javascript/preflight.js
@@ -21,9 +21,12 @@ function runPreFlightChecks() {
           function(scope) { return scope.length > 0 }
         ),
         ghUrl             = 'https://api.github.com/rate_limit',
-        authGhUrl         = ghUrl + '?access_token=' + token;
 
-  fetch(authGhUrl)
+  fetch(ghUrl, {
+    headers: {
+      'Authorization': 'token ' + token
+    }
+  })
     .then(function (response) { return response.headers; })
     .then(function (headers)  { return headers.get('x-oauth-scopes')  })
     .then(function (scopes)   { return scopes.split(', '); })


### PR DESCRIPTION
GitHub has deprecated passing the API token as a query parameter on requests.
Provide it via an HTTP header instead.

https://trello.com/c/Avv9sRJv/334-govwifi-support9662-github-api-deprecation-notice-for-authentication-via-url-query-parameters