### PR TITLE
Fix/preflight handlers

### DIFF
--- a/fourth-wall.css
+++ b/fourth-wall.css
@@ -26,6 +26,7 @@ body {
     background-color:green;
 }
 .failure, .error {
+    padding: 1rem;
     background-color: #BF1E2D;
 }
 .not-mergeable {

--- a/fourth-wall.css
+++ b/fourth-wall.css
@@ -25,10 +25,27 @@ body {
 .success {
     background-color:green;
 }
+
 .failure, .error {
     padding: 1rem;
     background-color: #BF1E2D;
+    color: white;
+    float: none;
+    margin: 0;
 }
+
+.error a {
+    color: white;
+}
+
+.error a:focus {
+    color: #0b0c0c;
+    outline: 3px solid transparent;
+    background-color: #ffdd00;
+    box-shadow: 0 -2px #ffdd00, 0 4px #0b0c0c;
+    text-decoration: none;
+}
+
 .not-mergeable {
     background-color: #9FA098;
     font-size: 0.9em;

--- a/index.html
+++ b/index.html
@@ -2,7 +2,6 @@
 <html>
 <head>
     <title>Fourth Wall</title>
-    <link rel="stylesheet" href="https://assets.publishing.service.gov.uk/static/fonts.css">
     <link rel="stylesheet" href="fourth-wall.css">
     <link rel="icon" type="image/png" href="favicon-32.png">
 </head>

--- a/javascript/core.js
+++ b/javascript/core.js
@@ -172,4 +172,8 @@
   FourthWall.wipHandling = (FourthWall.getQueryVariable('wiphandling') || 'small');
 
   FourthWall.wipStrings = ['WIP', 'DO NOT MERGE', 'REVIEW ONLY'];
+
+  FourthWall.appendErrorMessage = function(content) {
+    $(document.body).append(`<h3 class="error">${content}</h3>`);
+  };
 })();

--- a/javascript/core.js
+++ b/javascript/core.js
@@ -174,6 +174,6 @@
   FourthWall.wipStrings = ['WIP', 'DO NOT MERGE', 'REVIEW ONLY'];
 
   FourthWall.appendErrorMessage = function(content) {
-    $(document.body).append(`<h3 class="error">${content}</h3>`);
+    $(document.body).prepend(`<p class="error">${content}</p>`);
   };
 })();

--- a/javascript/preflight.js
+++ b/javascript/preflight.js
@@ -20,13 +20,28 @@ function runPreFlightChecks() {
         extraScopes       = (queryVars.extra_scopes || '').split(',').filter(
           function(scope) { return scope.length > 0 }
         ),
-        ghUrl             = 'https://api.github.com/rate_limit',
+        ghUrl             = 'https://api.github.com/rate_limit';
+
+  if (!token) {
+    FourthWall.appendErrorMessage(`You need to <a href="https://github.com/alphagov/fourth-wall#how-to-use">provide a valid token</a> in order to use Fourth Wall.`);
+    return;
+  }
 
   fetch(ghUrl, {
     headers: {
       'Authorization': 'token ' + token
     }
   })
+    .then(function(response) {
+      if (response.ok) {
+        return response;
+      } else {
+        response.text()
+          .then(function(text) {
+            FourthWall.appendErrorMessage(`Something went wrong during preflight request: ${text}`);
+          });
+      }
+    })
     .then(function (response) { return response.headers; })
     .then(function (headers)  { return headers.get('x-oauth-scopes')  })
     .then(function (scopes)   { return scopes.split(', '); })

--- a/spec/puppeteer.test.js
+++ b/spec/puppeteer.test.js
@@ -23,6 +23,6 @@ it('passes all tests', async (done) => {
   await page.waitForSelector('.passingAlert')
   const passed = await page.evaluate( () => document.querySelector('.passingAlert').textContent )
 
-  expect(passed).toEqual('Passing 54 specs')
+  expect(passed).toEqual('Passing 55 specs')
   done()
 })

--- a/spec/spec.fourth-wall.js
+++ b/spec/spec.fourth-wall.js
@@ -180,8 +180,14 @@ describe("Fourth Wall", function () {
       });
     }
 
-    it("should return true if the pull request is a draft", function() {
-      let pull = {get: function(key) { return key === "draft"; }};
+    it(`should return true if the pull request is a draft`, function() {
+      const pr = {
+        title: "Some PR",
+        draft: true
+      };
+
+      const pull = {get: function(key) { return pr[key] } };
+
       expect(FourthWall.isWip(pull)).toEqual(true);
     });
   });


### PR DESCRIPTION
# Description 
We left a syntax error in the previous PR so amend this but also the whole test suite to restore that glorious green badge.

# Details
* the preflights `const` declarations weren't terminated;
* add a helper to add an error header to the page;
* use that header in case of missing token or error in the request;
* fix the broken test in the suite;
* remove a dead link to some inexistent CSS.