### PR TITLE
Warn users about retirement on 22 September

### DIFF
--- a/javascript/preflight.js
+++ b/javascript/preflight.js
@@ -11,6 +11,8 @@ function runPreFlightChecks() {
     alert(isHttpMessage);
   }
 
+  FourthWall.appendErrorMessage(`This service will be retired on 22nd September. Contact the Digital Marketplace team if you would like to take it over instead.`);
+
   // We will:
   // - Make a request to the github rate limit endpoint
   //   (This will not affect the rate limit)


### PR DESCRIPTION
https://trello.com/c/OS5OSEVl/144-1-decide-whether-to-migrate-shared-repos-to-ccs

We recently discovered that the Digital Marketplace team was responsible for this repo. We don't have the time or expertise to fix the [accessibility issues](https://github.com/alphagov/fourth-wall/issues/133), and we're moving to CCS soon. We asked, and no other team in GDS/CDIO wanted to take it on. So we're going to retire it in an orderly fashion.

3 weeks is probably long enough for people to notice. They'll be able to find something else, or let us know if they want to take it on to stop the retirement. Otherwise, we'll switch it off after that date.

Thanks to @abersager who created this, @lfdebrux who's been maintaining it for the past year, and [everyone else](https://github.com/alphagov/fourth-wall/graphs/contributors) that contributed to a tool that was useful to many.

![image](https://user-images.githubusercontent.com/15256121/131541927-ba8a95fd-60f9-44ec-b9e1-9b67045778f7.png)
